### PR TITLE
Corrección de la URL de los posts relacionados.

### DIFF
--- a/_includes/last_posts.html
+++ b/_includes/last_posts.html
@@ -4,7 +4,7 @@
     {% for p in site.related_posts limit:5 %}
       <li>
         <h4>
-          <a href="{{ post.url }}">
+          <a href="{{ p.url }}">
             {{ p.title }}
           </a>
         </h4>


### PR DESCRIPTION
Situación actual: Todos los posts relacionados que aparecen dentro de un post dirigen al mismo post que se está visualizando.
Corrección: Cada post relacionado dirige a su propio contenido.